### PR TITLE
feat: add Windows build script and spec

### DIFF
--- a/BUILD_AND_RELEASE.md
+++ b/BUILD_AND_RELEASE.md
@@ -89,22 +89,30 @@ pip install -r requirements-build.txt
 
 ## Example PyInstaller commands
 
-Use these from the project root.
+Use these from the project root. Prefer the build scripts below — these are shown for reference only.
 
 ### Windows
 
-```bash
-pyinstaller --noconfirm --windowed --name "Weird Pixelator" main.py
+```powershell
+pyinstaller --noconfirm --windowed --icon icon.ico --name "Weird Pixelator" main.py
+```
+
+Use the build script instead:
+
+```powershell
+.\scripts\build_windows.ps1
 ```
 
 Output to upload:
 
-- the generated `dist/Weird Pixelator/` folder, zipped
+- `dist\Weird Pixelator Windows.zip` (contains the `Weird Pixelator\` folder)
 
 ### macOS
 
+Use the build script:
+
 ```bash
-pyinstaller --noconfirm --windowed --name "Weird Pixelator" main.py
+./scripts/build_macos.sh
 ```
 
 Output to upload:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Weird Pixelator is a desktop image tool for glitch art, color manipulation, blen
 3. Start the app:
    - `python main.py`
 
+## Build Windows app
+
+Use the included build script from PowerShell:
+
+- `.\scripts\build_windows.ps1`
+
+The script uses the checked-in source icon:
+
+- `icon.ico`
+
+The packaged app and a ready-to-upload zip are created in `dist/`.
+
 ## Build macOS app
 
 Use the included build script:

--- a/Weird Pixelator Windows.spec
+++ b/Weird Pixelator Windows.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from pathlib import Path
+
+
+APP_NAME = 'Weird Pixelator'
+APP_VERSION = '1.0.0'
+ICON_PATH = str(Path(SPECPATH) / 'assets' / 'icon.ico')
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    icon=ICON_PATH,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    version_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=APP_NAME,
+)

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Set-Location (Join-Path $PSScriptRoot '..')
+
+$pythonBin  = if ($env:PYTHON_BIN) { $env:PYTHON_BIN } else { '.\.venv\Scripts\python.exe' }
+$iconPng    = 'icon.png'
+$assetsDir  = 'assets'
+$iconIco    = "$assetsDir\icon.ico"
+$specFile   = 'Weird Pixelator Windows.spec'
+
+if (-not (Test-Path $pythonBin)) {
+    Write-Error "Python executable not found: $pythonBin"
+    exit 1
+}
+
+if (-not (Test-Path $iconPng)) {
+    Write-Error "Missing icon source: $iconPng"
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $assetsDir | Out-Null
+
+& $pythonBin -c "from PIL import Image; sizes=[16,32,48,64,128,256]; img=Image.open('icon.png').convert('RGBA'); imgs=[img.resize((s,s),Image.LANCZOS) for s in sizes]; imgs[0].save('assets/icon.ico',format='ICO',sizes=[(s,s) for s in sizes],append_images=imgs[1:])"
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+& $pythonBin -m PyInstaller --noconfirm "$specFile"
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$distFolder = 'dist\Weird Pixelator'
+$zipPath    = 'dist\Weird Pixelator Windows.zip'
+
+if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+Compress-Archive -Path $distFolder -DestinationPath $zipPath
+
+Write-Host ''
+Write-Host "Build complete: $zipPath"


### PR DESCRIPTION
- Add scripts/build_windows.ps1 mirroring the macOS build script
- Generate assets/icon.ico from icon.png via Pillow at build time
- Add 'Weird Pixelator Windows.spec' with icon and COLLECT (no macOS BUNDLE)
- Update README.md with Windows build instructions
- Update BUILD_AND_RELEASE.md to document the build scripts for each platform